### PR TITLE
Adds DetachableProp class and a DetachableGasPump example

### DIFF
--- a/Player/Player.tscn
+++ b/Player/Player.tscn
@@ -102,11 +102,11 @@ height = 2.65424
 
 [node name="Player" type="CharacterBody3D" groups=["damageables"]]
 collision_layer = 16
-collision_mask = 3
+collision_mask = 195
 axis_lock_angular_x = true
 axis_lock_angular_y = true
 axis_lock_angular_z = true
-platform_floor_layers = 4294967042
+platform_floor_layers = 4294967234
 script = ExtResource("1_rvo1c")
 acceleration = 6.0
 

--- a/Player/model/materials/face_mat.tres
+++ b/Player/model/materials/face_mat.tres
@@ -1,7 +1,7 @@
 [gd_resource type="ShaderMaterial" load_steps=3 format=3 uid="uid://dh42cdejchkr3"]
 
 [ext_resource type="Shader" path="res://Player/face_mat.gdshader" id="1_u8nh3"]
-[ext_resource type="Texture2D" uid="uid://ci7cn145ld3l5" path="res://Player/model/faces/closed.png" id="2_1ov2s"]
+[ext_resource type="Texture2D" uid="uid://dbag7f8i27ub1" path="res://Player/model/faces/open.png" id="2_c7hu7"]
 
 [resource]
 render_priority = 0
@@ -12,4 +12,4 @@ shader_parameter/screen_red_offset = Vector2(0, 0)
 shader_parameter/screen_green_offset = Vector2(0, 0)
 shader_parameter/screen_blue_offset = Vector2(0, 0)
 shader_parameter/pixel_size = 44.0
-shader_parameter/face_texture = ExtResource("2_1ov2s")
+shader_parameter/face_texture = ExtResource("2_c7hu7")

--- a/Player/model/materials/heart_core_mat.tres
+++ b/Player/model/materials/heart_core_mat.tres
@@ -4,4 +4,4 @@
 albedo_color = Color(0, 0, 0, 1)
 emission_enabled = true
 emission = Color(0, 1, 0.392157, 1)
-emission_energy_multiplier = 1.83329
+emission_energy_multiplier = 1.40048

--- a/cars/compact.tscn
+++ b/cars/compact.tscn
@@ -147,6 +147,7 @@ collision_mask = 83
 mass = 1000.0
 physics_material_override = SubResource("PhysicsMaterial_12ddh")
 freeze_mode = 1
+continuous_cd = true
 script = ExtResource("1_47vdl")
 front_left_wheel = NodePath("WheelFrontLeft")
 front_right_wheel = NodePath("WheelFrontRight")

--- a/city_scene.tscn
+++ b/city_scene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=3 uid="uid://df3ovqaugu3gp"]
+[gd_scene load_steps=18 format=3 uid="uid://df3ovqaugu3gp"]
 
 [ext_resource type="Texture2D" uid="uid://8v4spylpsh8c" path="res://assets/textures/1x1m_grid.png" id="1_s7ctx"]
 [ext_resource type="Material" uid="uid://ky6syqq4i4ae" path="res://assets/materials/road.tres" id="2_4u2h6"]
@@ -8,10 +8,8 @@
 [ext_resource type="PackedScene" uid="uid://c3ixqkc6k13yi" path="res://addons/gevp/scenes/vehicle_controller.tscn" id="6_62x7v"]
 [ext_resource type="Script" path="res://scripts/car_HUD.gd" id="6_eqxcn"]
 [ext_resource type="PackedScene" uid="uid://ciqrpd5675boy" path="res://Player/Player.tscn" id="6_yij02"]
-[ext_resource type="PackedScene" uid="uid://cmmani56m7eaj" path="res://collidables/trashbin_static.tscn" id="9_ypws5"]
 [ext_resource type="PackedScene" uid="uid://21febu6fhlg2" path="res://collidables/crash_object.tscn" id="10_aekul"]
-[ext_resource type="PackedScene" uid="uid://3o0ghab2l4ev" path="res://collidables/gas_pump.tscn" id="10_f0gvi"]
-[ext_resource type="PackedScene" uid="uid://co0uu1ghkv7wn" path="res://collidables/trash_bin.tscn" id="12_abnwu"]
+[ext_resource type="PackedScene" uid="uid://1doygxshb01r" path="res://collidables/detachable_gas_pump.tscn" id="13_rsd7i"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_d01qh"]
 albedo_texture = ExtResource("1_s7ctx")
@@ -387,28 +385,10 @@ theme = SubResource("Theme_id77h")
 
 [node name="CrashObjects" type="Node" parent="."]
 
-[node name="TrashbinStatic" parent="CrashObjects" instance=ExtResource("9_ypws5")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -18.6236, 1.59004, -39.9834)
+[node name="CrashableProp" parent="CrashObjects" instance=ExtResource("10_aekul")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -7, 1.1, 2)
 
-[node name="TrashbinStatic2" parent="CrashObjects" instance=ExtResource("9_ypws5")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -18.6236, 1.59004, -33.9834)
-
-[node name="TrashbinStatic3" parent="CrashObjects" instance=ExtResource("9_ypws5")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -18.6236, 1.59004, -27.9834)
-
-[node name="CrashObject" parent="CrashObjects" instance=ExtResource("10_aekul")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.562483, -9.56595)
-
-[node name="GasPump" parent="CrashObjects/CrashObject" instance=ExtResource("10_f0gvi")]
-
-[node name="CrashObject2" parent="CrashObjects" instance=ExtResource("10_aekul")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.45556, 0.562483, -20.3866)
-
-[node name="GasPump" parent="CrashObjects/CrashObject2" instance=ExtResource("10_f0gvi")]
-
-[node name="CrashObject3" parent="CrashObjects" instance=ExtResource("10_aekul")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.87576, 1.56248, -20.3834)
-
-[node name="TrashBin" parent="CrashObjects/CrashObject3" instance=ExtResource("12_abnwu")]
+[node name="DetachableGasPump" parent="CrashObjects" instance=ExtResource("13_rsd7i")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 1, 4)
 
 [connection signal="body_exited" from="BoundingArea3D" to="BoundingArea3D" method="destroyExitingNode"]

--- a/collidables/crash_object.tscn
+++ b/collidables/crash_object.tscn
@@ -1,6 +1,36 @@
-[gd_scene load_steps=2 format=3 uid="uid://21febu6fhlg2"]
+[gd_scene load_steps=5 format=3 uid="uid://21febu6fhlg2"]
 
 [ext_resource type="Script" path="res://collidables/CrashObject.gd" id="1_4djd8"]
 
-[node name="CrashObject" type="Area3D"]
+[sub_resource type="BoxMesh" id="BoxMesh_catmd"]
+
+[sub_resource type="ConvexPolygonShape3D" id="ConvexPolygonShape3D_jb8cv"]
+points = PackedVector3Array(-0.5, -0.5, -0.5, 0.5, 0.5, 0.5, 0.5, -0.5, 0.5, 0.5, 0.5, -0.5, -0.5, 0.5, 0.5, 0.5, -0.5, -0.5, -0.5, -0.5, 0.5, -0.5, 0.5, -0.5)
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_p7v6v"]
+radius = 1.0
+
+[node name="DetachableProp" type="Node3D"]
 script = ExtResource("1_4djd8")
+
+[node name="RigidBody3D" type="RigidBody3D" parent="."]
+collision_layer = 64
+collision_mask = 215
+freeze = true
+freeze_mode = 1
+max_contacts_reported = 10
+contact_monitor = true
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="RigidBody3D"]
+mesh = SubResource("BoxMesh_catmd")
+skeleton = NodePath("../..")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="RigidBody3D"]
+shape = SubResource("ConvexPolygonShape3D_jb8cv")
+
+[node name="Area3D" type="Area3D" parent="."]
+collision_layer = 256
+collision_mask = 2
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
+shape = SubResource("SphereShape3D_p7v6v")

--- a/collidables/detachable_gas_pump.gd
+++ b/collidables/detachable_gas_pump.gd
@@ -1,0 +1,15 @@
+extends DetachableProp
+
+@onready var fires: Node3D = $RigidBody3D/Fires
+
+
+func play_effect(body: Node3D) -> void:
+  if body.is_in_group("CanCrash"):
+    physics_body.apply_central_impulse(Vector3.UP * 100)
+    for fire in fires.get_children():
+      fire.emitting = true
+
+
+func stop_effect() -> void:
+  for fire in fires.get_children():
+    fire.emitting = false

--- a/collidables/detachable_gas_pump.tscn
+++ b/collidables/detachable_gas_pump.tscn
@@ -1,0 +1,91 @@
+[gd_scene load_steps=13 format=3 uid="uid://1doygxshb01r"]
+
+[ext_resource type="Script" path="res://collidables/detachable_gas_pump.gd" id="1_cx65w"]
+[ext_resource type="ArrayMesh" uid="uid://b86mrbh4a6ac8" path="res://assets/models/gasPump.obj" id="3_o54nt"]
+[ext_resource type="PackedScene" uid="uid://drtqj75y7cwtf" path="res://fire.tscn" id="4_0gsha"]
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_4icfp"]
+size = Vector3(2.45641, 3.51965, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_1x767"]
+vertex_color_use_as_albedo = true
+
+[sub_resource type="Gradient" id="Gradient_6ksbl"]
+offsets = PackedFloat32Array(0, 0.484582, 0.819383, 1)
+colors = PackedColorArray(1, 1, 1, 1, 0.932249, 0.891119, 2.31028e-06, 1, 0.920752, 0.355072, 0, 1, 0, 0, 0, 1)
+
+[sub_resource type="GradientTexture1D" id="GradientTexture1D_2d36g"]
+gradient = SubResource("Gradient_6ksbl")
+
+[sub_resource type="Curve" id="Curve_vbjrq"]
+_data = [Vector2(0.0392157, 1), 0.0, 0.0, 0, 0, Vector2(1, 0), -1.84081, 0.0, 0, 0]
+point_count = 2
+
+[sub_resource type="CurveTexture" id="CurveTexture_h0mbi"]
+curve = SubResource("Curve_vbjrq")
+
+[sub_resource type="ParticleProcessMaterial" id="ParticleProcessMaterial_7uuv0"]
+direction = Vector3(0, 1, 0)
+spread = 75.0
+initial_velocity_min = 8.0
+initial_velocity_max = 12.0
+damping_min = 5.0
+damping_max = 10.0
+color_ramp = SubResource("GradientTexture1D_2d36g")
+emission_curve = SubResource("CurveTexture_h0mbi")
+
+[sub_resource type="BoxMesh" id="BoxMesh_l5ueu"]
+size = Vector3(0.1, 0.1, 0.1)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_u06ru"]
+size = Vector3(2.45641, 3.51965, 1)
+
+[node name="DetachableGasPump" type="Node3D"]
+script = ExtResource("1_cx65w")
+
+[node name="RigidBody3D" type="RigidBody3D" parent="." groups=["CrashScene"]]
+collision_layer = 64
+collision_mask = 87
+mass = 30.0
+freeze = true
+freeze_mode = 1
+max_contacts_reported = 10
+contact_monitor = true
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="RigidBody3D"]
+mesh = ExtResource("3_o54nt")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="RigidBody3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00832367, 1.79281, 0)
+shape = SubResource("BoxShape3D_4icfp")
+
+[node name="Fires" type="Node3D" parent="RigidBody3D"]
+
+[node name="Fire" parent="RigidBody3D/Fires" instance=ExtResource("4_0gsha")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.90354, 0.648228, -8.17776e-05)
+emitting = false
+
+[node name="Fire2" parent="RigidBody3D/Fires" instance=ExtResource("4_0gsha")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.762578, 2.40752, -8.17776e-05)
+emitting = false
+
+[node name="Sparks" type="GPUParticles3D" parent="RigidBody3D/Fires"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.443619)
+material_override = SubResource("StandardMaterial3D_1x767")
+emitting = false
+amount = 16
+lifetime = 0.5
+one_shot = true
+explosiveness = 0.78
+randomness = 0.35
+visibility_aabb = AABB(-4.84702, -4, -4, 9.7204, 8, 8)
+process_material = SubResource("ParticleProcessMaterial_7uuv0")
+draw_pass_1 = SubResource("BoxMesh_l5ueu")
+
+[node name="Area3D" type="Area3D" parent="."]
+collision_layer = 256
+collision_mask = 2
+
+[node name="CollisionShape3D2" type="CollisionShape3D" parent="Area3D"]
+transform = Transform3D(1.5, 0, 0, 0, 1.5, 0, 0, 0, 1.5, -0.00832367, 1.79281, 0)
+shape = SubResource("BoxShape3D_u06ru")

--- a/collidables/gas_pump.gd
+++ b/collidables/gas_pump.gd
@@ -7,5 +7,8 @@ func _on_body_entered(body: Node) -> void:
         apply_impulse(body.global_transform.basis * 100)
 
 func _ready() -> void:
+    emit_fire()
+
+func emit_fire() -> void:
     for fire in fires.get_children():
         fire.emitting = true

--- a/project.godot
+++ b/project.godot
@@ -146,7 +146,9 @@ use={
 3d_physics/layer_4="Useable"
 3d_physics/layer_5="Player"
 3d_physics/layer_6="Latch"
-3d_physics/layer_7="CrashableScenery"
+3d_physics/layer_7="PhysicsProp"
+3d_physics/layer_8="StaticScenery"
+3d_physics/layer_9="PropUnfreezeRadius"
 
 [physics]
 


### PR DESCRIPTION
Attempting to make a base DetachableProp class for props that can be crashed into and broken, like bins and lampposts etc. Ported the existing gas pump prop over to the base class and got it to play & stop its fire effect and jump into the air a bit when first hit.